### PR TITLE
Visualise distograms and other minor updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -391,7 +391,7 @@ def javascript_exe_button(n_clicks, session_id):
 
     else:
         app.logger.info('Fetching example data')
-        session_utils.load_session('user_1', 34, session_id, cache, app.logger)
+        session_utils.load_session('user_1', 1, session_id, cache, app.logger)
         return "location.reload();", no_update
 
 

--- a/app.py
+++ b/app.py
@@ -391,7 +391,7 @@ def javascript_exe_button(n_clicks, session_id):
 
     else:
         app.logger.info('Fetching example data')
-        session_utils.load_session('user_1', 1, session_id, cache, app.logger)
+        session_utils.load_session('user_1', 35, session_id, cache, app.logger)
         return "location.reload();", no_update
 
 

--- a/app.py
+++ b/app.py
@@ -409,10 +409,13 @@ def javascript_exe_button(n_clicks, session_id):
                State({'type': "halfsquare-select", 'index': ALL}, 'value'),
                State("transparent-tracks-switch", 'value'),
                State('superimpose-maps-switch', 'value'),
+               State('distance-matrix-switch', 'value'),
+               State('verbose-labels-switch', 'value'),
                State({'type': 'colorpalette-select', 'index': ALL}, 'value'),
                State('session-id', 'data')])
 def create_ConPlot(plot_click, refresh_click, factor, contact_marker_size, track_marker_size, track_separation,
-                   track_selection, cmap_selection, transparent, superimpose, selected_palettes, session_id):
+                   track_selection, cmap_selection, transparent, superimpose, distance_matrix, verbose_labels,
+                   selected_palettes, session_id):
     trigger = dash.callback_context.triggered[0]
     cache = keydb.KeyDB(connection_pool=keydb_pool)
 
@@ -426,13 +429,15 @@ def create_ConPlot(plot_click, refresh_click, factor, contact_marker_size, track
     if any([True for x in (factor, contact_marker_size, track_marker_size, track_separation) if x is None or x < 0]):
         app.logger.info('Session {} invalid display control value detected'.format(session_id))
         return no_update, components.InvalidInputModal(), no_update, no_update
+    elif superimpose and distance_matrix:
+        return no_update, components.InvalidSuperposeDistanceMatrixModal(), no_update, no_update
     elif superimpose and ('---' in cmap_selection or len(set(cmap_selection)) == 1):
         return no_update, components.InvalidMapSelectionModal(), no_update, no_update
 
     app.logger.info('Session {} creating conplot'.format(session_id))
     return plot_utils.create_ConPlot(session_id, cache, trigger, track_selection, cmap_selection, selected_palettes,
                                      factor, contact_marker_size, track_marker_size, track_separation, transparent,
-                                     superimpose)
+                                     superimpose, distance_matrix, verbose_labels)
 
 
 # ==============================================================

--- a/app.py
+++ b/app.py
@@ -386,10 +386,10 @@ def remove_dataset(alerts_open, session_id):
     return None
 
 
-@app.callback(Output('refresh-page', 'run'),
-              [Input('load-example-button', 'n_clicks')],
+@app.callback(Output('javascript-exe', 'run'),
+              [Input({'type': 'javascript-exe-button', 'index': ALL}, 'n_clicks')],
               [State('session-id', 'data')])
-def refresh_button_clicked(n_clicks, session_id):
+def load_example_data(n_clicks, session_id):
     trigger = dash.callback_context.triggered[0]
     cache = keydb.KeyDB(connection_pool=keydb_pool)
 

--- a/app.py
+++ b/app.py
@@ -394,7 +394,7 @@ def javascript_exe_button(n_clicks, session_id):
     else:
         app.logger.info('Fetching example data')
         try:
-            session_utils.load_session('user_1', 4, session_id, cache, app.logger)
+            session_utils.load_session('user_1', 35, session_id, cache, app.logger)
         except (psycopg2.OperationalError, AttributeError) as e:
             app.logger.error('Unable to fetch example data: {}'.format(e))
             return no_update, components.ExampleSessionConnectionErrorModal(), no_update

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -7,6 +7,7 @@ class UserReadableTrackNames(Enum):
     disorder = 'Seq. Disorder'
     conservation = 'Seq. Conservation'
     custom = 'Custom Tracks'
+    heatmap = 'Heatmap'
 
 
 class EmailIssueReference(Enum):
@@ -25,6 +26,12 @@ def SessionStoreModal(*args, **kwargs):
     from components.modals import SessionStoreModal
 
     return SessionStoreModal(*args, **kwargs)
+
+
+def InvalidSuperposeDistanceMatrixModal(*args, **kwargs):
+    from components.modals import InvalidSuperposeDistanceMatrixModal
+
+    return InvalidSuperposeDistanceMatrixModal(*args, **kwargs)
 
 
 def GdprPolicySectionOne(*args, **kwargs):
@@ -625,6 +632,18 @@ def SuperimposeSwitch(*args, **kwargs):
     from components.inputgroups import SuperimposeSwitch
 
     return SuperimposeSwitch(*args, **kwargs)
+
+
+def DistanceMatrixSwitch(*args, **kwargs):
+    from components.inputgroups import DistanceMatrixSwitch
+
+    return DistanceMatrixSwitch(*args, **kwargs)
+
+
+def VerboseLabelsSwitch(*args, **kwargs):
+    from components.inputgroups import VerboseLabelsSwitch
+
+    return VerboseLabelsSwitch(*args, **kwargs)
 
 
 def TrackLayoutSelector(*args, **kwargs):

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -352,6 +352,12 @@ def TutorialList(*args, **kwargs):
     return TutorialList(*args, **kwargs)
 
 
+def ServerStatusList(*args, **kwargs):
+    from components.listgrpoups import ServerStatusList
+
+    return ServerStatusList(*args, **kwargs)
+
+
 def SessionTimedOutToast(*args, **kwargs):
     from components.toasts import SessionTimedOutToast
 

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -28,6 +28,12 @@ def SessionStoreModal(*args, **kwargs):
     return SessionStoreModal(*args, **kwargs)
 
 
+def ExampleSessionConnectionErrorModal(*args, **kwargs):
+    from components.modals import ExampleSessionConnectionErrorModal
+
+    return ExampleSessionConnectionErrorModal(*args, **kwargs)
+
+
 def InvalidSuperposeDistanceMatrixModal(*args, **kwargs):
     from components.modals import InvalidSuperposeDistanceMatrixModal
 

--- a/components/badges.py
+++ b/components/badges.py
@@ -10,4 +10,4 @@ def HelpBadge():
 
 def ExampleLinkButton(url):
     return dbc.Button('Example', size='sm', outline=True, color='primary',
-                      id={'index': 'load-example-button', 'type': 'javascript-exe-button'})
+                      id={'index': 'load-example', 'type': 'javascript-exe-button'})

--- a/components/badges.py
+++ b/components/badges.py
@@ -9,4 +9,5 @@ def HelpBadge():
 
 
 def ExampleLinkButton(url):
-    return dbc.Button('Example', size='sm', outline=True, color='primary', id='load-example-button')
+    return dbc.Button('Example', size='sm', outline=True, color='primary',
+                      id={'index': 'load-example-button', 'type': 'javascript-exe-button'})

--- a/components/cards.py
+++ b/components/cards.py
@@ -115,7 +115,7 @@ def AdditionalTrackFormatSelectionCard():
 def ContactUploadCard():
     return dbc.Card([
         dbc.CardBody([
-            html.H5('Contact Map', style={'text-align': "center"}),
+            html.H5('Contact Information', style={'text-align': "center"}),
             html.Br(),
             ContactFormatSelectionCard(),
             html.Br(),
@@ -194,6 +194,8 @@ def NoPlotDisplayControlCard(contact_marker_size, track_marker_size, track_separ
             dbc.Input(id='L-cutoff-input', value=2),
             components.TransparentSwitch(True),
             components.SuperimposeSwitch(False),
+            components.DistanceMatrixSwitch(False),
+            components.VerboseLabelsSwitch(False),
             dbc.Input(id='contact-marker-size-input', value=contact_marker_size),
             dbc.Input(id='track-marker-size-input', value=track_marker_size),
             dbc.Input(id='track-separation-size-input', value=track_separation),
@@ -206,7 +208,8 @@ def NoPlotDisplayControlCard(contact_marker_size, track_marker_size, track_separ
 
 def DisplayControlCard(available_tracks=None, selected_tracks=None, selected_cmaps=None, available_maps=None,
                        selected_palettes=None, factor=2, contact_marker_size=5, track_marker_size=5,
-                       track_separation=2, transparent=True, superimpose=False):
+                       track_separation=2, transparent=True, superimpose=False, distance_matrix=False,
+                       verbose_labels=False):
     if available_tracks is None or available_maps is None or selected_palettes is None:
         return dbc.Card(
             dbc.CardBody(
@@ -229,16 +232,21 @@ def DisplayControlCard(available_tracks=None, selected_tracks=None, selected_cma
                             html.H5("Adjust contact map", className="card-text", style={'text-align': "center"}),
                             html.Hr(),
                             html.Br(),
-                            dbc.Card(components.LFactorSelector(factor), outline=False),
+                            dbc.Card(components.LFactorSelector(factor, distance_matrix), outline=False),
                             html.Br(),
-                            dbc.Card(components.SizeSelector('contact-marker-size-input', contact_marker_size, 1, 15),
-                                     outline=False),
+                            dbc.Card(
+                                components.SizeSelector(
+                                    'contact-marker-size-input', contact_marker_size, 1, 15, disabled=distance_matrix
+                                ), outline=False
+                            ),
                             html.Br(),
                             HalfSquareSelectionCard('A', selection=selected_cmaps[0], available_cmaps=available_maps),
                             html.Br(),
                             HalfSquareSelectionCard('B', selection=selected_cmaps[1], available_cmaps=available_maps),
                             html.Br(),
                             components.SuperimposeSwitch(superimpose),
+                            components.DistanceMatrixSwitch(distance_matrix),
+                            components.VerboseLabelsSwitch(verbose_labels),
                             html.Br(),
                             html.H5('Adjust additional tracks', className="card-text", style={'text-align': "center"}),
                             html.Hr(),
@@ -287,6 +295,8 @@ def DisplayControlCard(available_tracks=None, selected_tracks=None, selected_cma
                             ColorPaletteSelectionCard('conservation', selected_palettes[3]),
                             html.Br(),
                             ColorPaletteSelectionCard('custom', selected_palettes[4]),
+                            html.Br(),
+                            ColorPaletteSelectionCard('heatmap', selected_palettes[5]),
                             html.Br(),
                         ])
                     ]

--- a/components/inputgroups.py
+++ b/components/inputgroups.py
@@ -3,13 +3,13 @@ import dash_html_components as html
 from loaders import AdditionalDatasetReference
 from parsers import ContactFormats
 from components import EmailIssueReference, UserReadableTrackNames
-from utils.plot_utils import DefaultTrackLayout
+from utils.plot_utils import PaletteDefaultLayout
 from utils import UrlIndex
 
 
 def ContactFormatSelector():
     format_list = sorted([{"label": map_format, "value": map_format} for map_format in
-                          ContactFormats.__dict__.keys() if '_' not in map_format], key=lambda k: k['label'])
+                          ContactFormats.__dict__.keys() if not map_format.islower()], key=lambda k: k['label'])
     return dbc.InputGroup(
         [
             dbc.Select(
@@ -21,20 +21,30 @@ def ContactFormatSelector():
     )
 
 
-def SizeSelector(id, marker_size, min, max, text='Size'):
+def SizeSelector(id, marker_size, min, max, text='Size', disabled=False):
+    if disabled == [1]:
+        disabled = True
+    elif not disabled:
+        disabled = False
+
     return dbc.InputGroup(
         [
             dbc.InputGroupAddon(text, addon_type="prepend"),
-            dbc.Input(id=id, type="number", min=min, max=max, step=1, value=marker_size),
+            dbc.Input(id=id, type="number", min=min, max=max, step=1, value=marker_size, disabled=disabled),
         ]
     )
 
 
-def LFactorSelector(factor=2):
+def LFactorSelector(factor=2, disabled=False):
+    if disabled == [1]:
+        disabled = True
+    elif not disabled:
+        disabled = False
+
     return dbc.InputGroup(
         [
             dbc.InputGroupAddon("L /", addon_type="prepend"),
-            dbc.Input(id='L-cutoff-input', type="number", min=0, max=10, step=1, value=factor)
+            dbc.Input(id='L-cutoff-input', type="number", min=0, max=10, step=1, value=factor, disabled=disabled)
         ]
     )
 
@@ -72,13 +82,12 @@ def TrackLayoutSelector(idx, options, value):
 
 
 def PaletteSelector(dataset, options, value):
-    index = [x.value for x in DefaultTrackLayout].index(dataset.encode())
-    return dbc.InputGroup(
-        [
-            dbc.InputGroupAddon(UserReadableTrackNames.__getattr__(dataset).value, addon_type="prepend"),
-            dbc.Select(id={'type': 'colorpalette-select', 'index': index}, options=options, value=value)
-        ]
-    )
+    index = [x.value for x in PaletteDefaultLayout].index(dataset.encode())
+
+    return dbc.InputGroup([
+        dbc.InputGroupAddon(UserReadableTrackNames.__getattr__(dataset).value, addon_type="prepend"),
+        dbc.Select(id={'type': 'colorpalette-select', 'index': index}, options=options, value=value)
+    ])
 
 
 def EmailInput(id='email-input'):
@@ -164,6 +173,26 @@ def TransparentSwitch(transparent):
     )
 
 
+def VerboseLabelsSwitch(verbose):
+    if verbose:
+        value = [1]
+    else:
+        value = []
+
+    return dbc.FormGroup(
+        [
+            dbc.Checklist(
+                options=[
+                    {"label": "Verbose labels", "value": 1},
+                ],
+                value=value,
+                id="verbose-labels-switch",
+                switch=True,
+            ),
+        ], className='mr-1'
+    )
+
+
 def SuperimposeSwitch(superimpose):
     if superimpose:
         value = [1]
@@ -178,6 +207,26 @@ def SuperimposeSwitch(superimpose):
                 ],
                 value=value,
                 id="superimpose-maps-switch",
+                switch=True,
+            ),
+        ], className='mr-1'
+    )
+
+
+def DistanceMatrixSwitch(make_matrix):
+    if make_matrix:
+        value = [1]
+    else:
+        value = []
+
+    return dbc.FormGroup(
+        [
+            dbc.Checklist(
+                options=[
+                    {"label": "Create heatmap", "value": 1},
+                ],
+                value=value,
+                id="distance-matrix-switch",
                 switch=True,
             ),
         ], className='mr-1'

--- a/components/links.py
+++ b/components/links.py
@@ -5,7 +5,7 @@ from utils import UrlIndex
 
 def StartNewSessionLink():
     return dbc.Button("Start new session", block=True, color='danger',
-                      id={'type': 'clear-storage-button', 'index': '1'})
+                      id={'type': 'javascript-exe-button', 'index': 'new-session'})
 
 
 def GitHubLink():

--- a/components/listgrpoups.py
+++ b/components/listgrpoups.py
@@ -1,7 +1,7 @@
 from components import ShareWithInput, SessionListType
 import dash_bootstrap_components as dbc
 import dash_html_components as html
-from utils import postgres_utils, UrlIndex
+from utils import postgres_utils, UrlIndex, conplot_version, is_redis_available, get_active_sessions
 
 
 def SessionListItem(session, list_type, color='secondary'):
@@ -93,6 +93,49 @@ def TutorialList():
             TutorialItem(idx=1, name='Creating your first plot'),
             TutorialItem(idx=2, name='Compare a contact prediction with a PDB file'),
             TutorialItem(idx=3, name='Storing, loading and sharing a session'),
+        ], style={'width': '75%'}
+        ), justify='center', align='center')
+
+
+def StatusItem(idx, name, status_badge):
+    style = {'border-bottom': '1px solid', 'border-left': '1px solid', 'border-right': '1px solid'}
+    if idx == 1:
+        style['border-top'] = '1px solid'
+
+    return dbc.ListGroupItem([
+        dbc.Row([
+            dbc.Col(
+                html.H5(name, style={'vertical-align': 'middle', 'margin-top': 8}),
+                style={'align-items': 'center', 'justify-content': 'left', 'display': 'flex'}, width=9
+            ),
+            dbc.Col(
+                status_badge,
+                style={'align-items': 'center', 'justify-content': 'right', 'display': 'flex'}
+            )
+        ], justify='around', align='around')
+    ], style=style)
+
+
+def ServerStatusList(cache):
+    version = html.H4(dbc.Badge(conplot_version(), color='primary', pill=True))
+    if is_redis_available(cache):
+        redis_badge = html.H4(dbc.Badge('OK', color='success', pill=True))
+        active_sessions = html.H4(dbc.Badge(get_active_sessions(cache), color='primary', pill=True))
+    else:
+        redis_badge = html.H4(dbc.Badge('ERROR', color='danger', pill=True))
+        active_sessions = html.H4(dbc.Badge('ERROR', color='danger', pill=True))
+
+    if postgres_utils.is_postgres_available():
+        postgres_badge = html.H4(dbc.Badge('OK', color='success', pill=True))
+    else:
+        postgres_badge = html.H4(dbc.Badge('ERROR', color='danger', pill=True))
+
+    return dbc.Row(
+        dbc.ListGroup([
+            StatusItem(idx=1, name='Cache status', status_badge=redis_badge),
+            StatusItem(idx=2, name='Database status', status_badge=postgres_badge),
+            StatusItem(idx=3, name='Server load', status_badge=active_sessions),
+            StatusItem(idx=4, name='App version', status_badge=version)
         ], style={'width': '75%'}
         ), justify='center', align='center')
 

--- a/components/listgrpoups.py
+++ b/components/listgrpoups.py
@@ -330,7 +330,7 @@ def MandatoryInputHelpList():
                 'any given time. If you want to upload a new sequence, that means you will '
                 'need to delete the one you uploaded already first.',
                 style={"font-size": "110%", 'text-align': "justify"}),
-        html.Li(['Contact map file. This file informs about which residue pairs are in close '
+        html.Li(['Contact information file. This file informs about which residue pairs are in close '
                  'contact in the three-dimensional structure of the protein of interest. There '
                  'are many formats used for such files, but ConPlot is able to parse the '
                  'most common ones. If you wish to upload a contact map file in a format not supported '

--- a/components/modals.py
+++ b/components/modals.py
@@ -497,6 +497,19 @@ def PostgresConnectionErrorModal():
     ], id='postgres-connection-error-modal', is_open=True, backdrop='static', keyboard=False)
 
 
+def ExampleSessionConnectionErrorModal():
+    return dbc.Modal([
+        ModalHeader("PostgreSQL connection error"),
+        dbc.ModalBody([
+            html.P(['It was impossible to connect with PostgreSQL database in order to get the example session. If '
+                    'you are using ConPlot web services on ', html.I('www.conplot.org'),
+                    ' please report this issue in the "Get in touch" tab. While we fix this, you can download the '
+                    'example data ', dbc.CardLink(html.U('here'), href=UrlIndex.EXAMPLE_DATA.value), "."],
+                   style={'text-align': "justify"}),
+        ]),
+    ], id='example-session-error-modal', is_open=True)
+
+
 def SlackConnectionErrorModal():
     return dbc.Modal([
         ModalHeader("Helpdesk connection error"),

--- a/components/modals.py
+++ b/components/modals.py
@@ -49,6 +49,16 @@ def InvalidMapSelectionModal():
     ], id='invalid-map-selection-modal', is_open=True)
 
 
+def InvalidSuperposeDistanceMatrixModal():
+    return dbc.Modal([
+        ModalHeader("Invalid Input"),
+        dbc.ModalBody([
+            html.P("""Superposition of heatmaps is not supported yet!""",
+                   style={'text-align': "justify"})
+        ]),
+    ], id='invalid-map-selection-modal', is_open=True)
+
+
 def SequenceAlreadyUploadedModal():
     return dbc.Modal([
         ModalHeader("Sequence already uploaded"),
@@ -147,6 +157,7 @@ def SuccessContactFormModal():
         ),
     ], id='success-contact-form-modal', is_open=True)
 
+
 def SuccessCreateUserModal(username):
     return dbc.Modal([
         ModalHeader(html.H4("Success", className="alert-heading", style={'color': 'green'})),
@@ -155,7 +166,6 @@ def SuccessCreateUserModal(username):
                    style={'text-align': "justify"})
         ),
     ], id='success-contact-form-modal', is_open=True)
-
 
 
 def CustomFormatDescriptionModal():

--- a/components/tooltips.py
+++ b/components/tooltips.py
@@ -1,7 +1,6 @@
 import dash_html_components as html
 import dash_bootstrap_components as dbc
 from components import HelpBadge, ExampleLinkButton
-import visdcc
 
 
 def HelpToolTip(id, text, msg, example_url=None):
@@ -17,7 +16,6 @@ def HelpToolTip(id, text, msg, example_url=None):
         children.append(
             html.Span([
                 ExampleLinkButton(example_url),
-                visdcc.Run_js(id='refresh-page')
             ], id='{}-example-tooltip'.format(id))
         )
         children.append(dbc.Tooltip('Click here to get example data', target='{}-example-tooltip'.format(id)))

--- a/layouts/base.py
+++ b/layouts/base.py
@@ -1,5 +1,6 @@
 import dash_html_components as html
 import dash_core_components as dcc
+import visdcc
 
 
 def Base(session_id):
@@ -7,4 +8,5 @@ def Base(session_id):
         dcc.Store(id='session-id', data=session_id, storage_type='session'),
         dcc.Location(id='url', refresh=False),
         html.Div(id='page-content'),
+        visdcc.Run_js(id='javascript-exe')
     ])

--- a/layouts/base.py
+++ b/layouts/base.py
@@ -8,5 +8,6 @@ def Base(session_id):
         dcc.Store(id='session-id', data=session_id, storage_type='session'),
         dcc.Location(id='url', refresh=False),
         html.Div(id='page-content'),
-        visdcc.Run_js(id='javascript-exe')
+        visdcc.Run_js(id='javascript-exe'),
+        html.Div(id='javascript-exe-modal-div')
     ])

--- a/layouts/help.py
+++ b/layouts/help.py
@@ -4,7 +4,7 @@ import dash_bootstrap_components as dbc
 from utils import UrlIndex
 
 
-def Body():
+def Body(cache):
     return html.Div(
         [
             html.Br(),
@@ -260,8 +260,13 @@ def Body():
                                     'disabled. Similarly, you will not be able to get in touch with us using the '
                                     '"Get in touch" tab.']),
                             html.Br(),
-                            html.H4('9. Privacy Policy', className="card-text",
-                                    style={'text-align': "center"}),
+                            html.H4('9. Server status', className="card-text", style={'text-align': "center"}),
+                            html.Hr(),
+                            html.Br(),
+                            components.ServerStatusList(cache),
+                            html.Br(),
+                            html.Br(),
+                            html.H4('10. Privacy Policy', className="card-text", style={'text-align': "center"}),
                             html.Hr(),
                             html.Br(),
                             components.GdprPolicyAlert(False)
@@ -273,10 +278,10 @@ def Body():
     )
 
 
-def Help(session_id, username):
+def Help(session_id, username, cache):
     return html.Div([
         components.Header(username),
         components.NavBar(UrlIndex.HELP.value),
-        Body(),
+        Body(cache),
         components.Footer()
     ])

--- a/layouts/plot.py
+++ b/layouts/plot.py
@@ -1,14 +1,13 @@
+import components
 from utils import UrlIndex, get_display_control_card, load_display_settings, load_figure_json
 import dash_core_components as dcc
 import dash_html_components as html
-from components import NavBar, Header, PlotPlaceHolder, DisplayControlCard, MandatoryUploadCard, \
-    AdditionalTracksUploadCard, StoreSessionCard
 import dash_bootstrap_components as dbc
 
 
 def Body(username, figure_json=None, display_settings_json=None):
     if figure_json is None:
-        graph = PlotPlaceHolder()
+        graph = components.PlotPlaceHolder()
     else:
         graph = dcc.Graph(
             className='square-content', id='plot-graph', figure=load_figure_json(figure_json),
@@ -17,7 +16,7 @@ def Body(username, figure_json=None, display_settings_json=None):
         )
 
     if display_settings_json is None:
-        display_control_card = DisplayControlCard()
+        display_control_card = components.DisplayControlCard()
         adjust_plot_disabled = True
     else:
         display_settings = load_display_settings(display_settings_json)
@@ -28,7 +27,7 @@ def Body(username, figure_json=None, display_settings_json=None):
         dbc.Spinner(html.Div(id='contact-upload-modal-div'), fullscreen=True, fullscreenClassName="spinner-with-text"),
         dbc.Spinner(html.Div(id='sequence-upload-modal-div'), fullscreen=True),
         dbc.Spinner(html.Div(id='removefiles-modal-div'), fullscreen=True),
-        dbc.Spinner(html.Div(id='plot-modal-div'), fullscreen=True),
+        dbc.Spinner(html.Div(id='plot-modal-div'), fullscreen=True, fullscreenClassName="spinner-with-text"),
         dbc.Spinner(html.Div(id='additional-tracks-upload-modal-div'), fullscreen=True),
         dbc.Spinner(html.Div(id='store-session-modal-div'), fullscreen=True),
         html.Br(),
@@ -37,13 +36,13 @@ def Body(username, figure_json=None, display_settings_json=None):
                 html.Div([
                     dbc.Card([
                         dbc.CardBody(
-                            MandatoryUploadCard()
+                            components.MandatoryUploadCard()
                         ),
                         dbc.CardBody(
-                            AdditionalTracksUploadCard(),
+                            components.AdditionalTracksUploadCard(),
                         ),
                         dbc.CardBody(
-                            StoreSessionCard(username),
+                            components.StoreSessionCard(username),
                         )
                     ])
                 ], className='InputPanel', style={'height': '70vh', 'overflow-y': 'scroll'}),
@@ -75,7 +74,7 @@ def Body(username, figure_json=None, display_settings_json=None):
 
 def Plot(session_id, username, figure=None, display_settings=None):
     return html.Div([
-        Header(username),
-        NavBar(UrlIndex.PLOT.value),
+        components.Header(username),
+        components.NavBar(UrlIndex.PLOT.value),
         Body(username, figure, display_settings)
     ])

--- a/parsers/__init__.py
+++ b/parsers/__init__.py
@@ -64,7 +64,7 @@ class ParserFormats(Enum):
     PSICOV = ContactParser
     METAPSICOV = ContactParser
     NEBCON = ContactParser
-    CASPRR = ContactParser
+    CASPRR_MODE1 = ContactParser
     GREMLIN = ContactParser
     EPCMAP = ContactParser
     EVFOLD = ContactParser
@@ -79,29 +79,31 @@ class ParserFormats(Enum):
     CCMPRED = CCMpredParser
     COLSTATS = CCMpredParser
     PDB = PDBParser
+    CASPRR_MODE2 = DistogramParser
 
 
 class ContactFormats(Enum):
     PSICOV = 0
     METAPSICOV = 1
     NEBCON = 2
-    CASPRR = 3
-    GREMLIN = 4
-    EPCMAP = 5
-    EVFOLD = 6
-    FREECONTACT = 7
-    PLMDCA = 8
-    PCONS = 9
-    FLIB = 10
-    SAINT2 = 11
-    BCLCONTCATS = 12
-    BBCONTACTS = 13
-    COMSAT = 14
-    CCMPRED = 15
-    COLSTATS = 16
-    MAPALIGN = 17
-    ALEIGEN = 18
-    PDB = 19
+    CASPRR_MODE1 = 3
+    CASPRR_MODE2 = 4
+    GREMLIN = 5
+    EPCMAP = 6
+    EVFOLD = 7
+    FREECONTACT = 8
+    PLMDCA = 9
+    PCONS = 10
+    FLIB = 11
+    SAINT2 = 12
+    BCLCONTCATS = 13
+    BBCONTACTS = 14
+    COMSAT = 15
+    CCMPRED = 16
+    COLSTATS = 17
+    MAPALIGN = 18
+    ALEIGEN = 19
+    PDB = 20
 
 
 class MembraneStates(Enum):

--- a/parsers/__init__.py
+++ b/parsers/__init__.py
@@ -64,7 +64,7 @@ class ParserFormats(Enum):
     PSICOV = ContactParser
     METAPSICOV = ContactParser
     NEBCON = ContactParser
-    CASPRR_MODE1 = ContactParser
+    CASPRR_MODE_1 = ContactParser
     GREMLIN = ContactParser
     EPCMAP = ContactParser
     EVFOLD = ContactParser
@@ -79,15 +79,15 @@ class ParserFormats(Enum):
     CCMPRED = CCMpredParser
     COLSTATS = CCMpredParser
     PDB = PDBParser
-    CASPRR_MODE2 = DistogramParser
+    CASPRR_MODE_2 = DistogramParser
 
 
 class ContactFormats(Enum):
     PSICOV = 0
     METAPSICOV = 1
     NEBCON = 2
-    CASPRR_MODE1 = 3
-    CASPRR_MODE2 = 4
+    CASPRR_MODE_1 = 3
+    CASPRR_MODE_2 = 4
     GREMLIN = 5
     EPCMAP = 6
     EVFOLD = 7

--- a/parsers/__init__.py
+++ b/parsers/__init__.py
@@ -7,6 +7,12 @@ def ConsurfParser(*args, **kwargs):
     return ConsurfParser(*args, **kwargs)
 
 
+def DistogramParser(*args, **kwargs):
+    from parsers.distogramparser import DistogramParser
+
+    return DistogramParser(*args, **kwargs)
+
+
 def TopconsParser(*args, **kwargs):
     from parsers.topconsparser import TopconsParser
 

--- a/parsers/ccmpredparser.py
+++ b/parsers/ccmpredparser.py
@@ -14,7 +14,10 @@ def CCMpredParser(input):
             continue
 
         for res_2, raw_score in enumerate(line, 1):
-            raw_score = float(raw_score)
+            try:
+                raw_score = float(raw_score)
+            except ValueError:
+                raise InvalidFormat('Unable to parse contacts')
             if raw_score == '' or raw_score < 0.1:
                 continue
 

--- a/parsers/contactparser.py
+++ b/parsers/contactparser.py
@@ -9,7 +9,7 @@ class FieldSeparatorContactFormats(Enum):
     PSICOV = re.compile(r'\s+')
     METAPSICOV = re.compile(r'\s+')
     NEBCON = re.compile(r'\s+')
-    CASPRR_MODE1 = re.compile(r'\s+')
+    CASPRR_MODE_1 = re.compile(r'\s+')
     GREMLIN = re.compile(r'\s+')
     EPCMAP = re.compile(r'\s+')
     EVFOLD = re.compile(r'\s+')
@@ -29,7 +29,7 @@ class LineSizeContactFormats(Enum):
     PSICOV = 5
     METAPSICOV = 5
     NEBCON = 5
-    CASPRR_MODE1 = 5
+    CASPRR_MODE_1 = 5
     GREMLIN = 5
     EPCMAP = 5
     EVFOLD = 5
@@ -49,7 +49,7 @@ class FieldResidueOneContactFormats(Enum):
     PSICOV = 0
     METAPSICOV = 0
     NEBCON = 0
-    CASPRR_MODE1 = 0
+    CASPRR_MODE_1 = 0
     GREMLIN = 0
     EPCMAP = 0
     EVFOLD = 0
@@ -69,7 +69,7 @@ class FieldResidueTwoContactFormats(Enum):
     PSICOV = 1
     METAPSICOV = 1
     NEBCON = 1
-    CASPRR_MODE1 = 1
+    CASPRR_MODE_1 = 1
     GREMLIN = 1
     EPCMAP = 1
     EVFOLD = 2
@@ -89,7 +89,7 @@ class FieldRawScoreContactFormats(Enum):
     PSICOV = 4
     METAPSICOV = 4
     NEBCON = 4
-    CASPRR_MODE1 = 4
+    CASPRR_MODE_1 = 4
     GREMLIN = 4
     EPCMAP = 4
     EVFOLD = 5

--- a/parsers/contactparser.py
+++ b/parsers/contactparser.py
@@ -9,7 +9,7 @@ class FieldSeparatorContactFormats(Enum):
     PSICOV = re.compile(r'\s+')
     METAPSICOV = re.compile(r'\s+')
     NEBCON = re.compile(r'\s+')
-    CASPRR = re.compile(r'\s+')
+    CASPRR_MODE1 = re.compile(r'\s+')
     GREMLIN = re.compile(r'\s+')
     EPCMAP = re.compile(r'\s+')
     EVFOLD = re.compile(r'\s+')
@@ -29,7 +29,7 @@ class LineSizeContactFormats(Enum):
     PSICOV = 5
     METAPSICOV = 5
     NEBCON = 5
-    CASPRR = 5
+    CASPRR_MODE1 = 5
     GREMLIN = 5
     EPCMAP = 5
     EVFOLD = 5
@@ -49,7 +49,7 @@ class FieldResidueOneContactFormats(Enum):
     PSICOV = 0
     METAPSICOV = 0
     NEBCON = 0
-    CASPRR = 0
+    CASPRR_MODE1 = 0
     GREMLIN = 0
     EPCMAP = 0
     EVFOLD = 0
@@ -69,7 +69,7 @@ class FieldResidueTwoContactFormats(Enum):
     PSICOV = 1
     METAPSICOV = 1
     NEBCON = 1
-    CASPRR = 1
+    CASPRR_MODE1 = 1
     GREMLIN = 1
     EPCMAP = 1
     EVFOLD = 2
@@ -89,7 +89,7 @@ class FieldRawScoreContactFormats(Enum):
     PSICOV = 4
     METAPSICOV = 4
     NEBCON = 4
-    CASPRR = 4
+    CASPRR_MODE1 = 4
     GREMLIN = 4
     EPCMAP = 4
     EVFOLD = 5

--- a/parsers/distogramparser.py
+++ b/parsers/distogramparser.py
@@ -3,7 +3,7 @@ from utils import unique_by_key
 from utils.exceptions import InvalidFormat
 
 
-def DistogramParser(input):
+def DistogramParser(input, input_format=None):
     contents = input.split('\n')
     output = []
     res_1_idx = 0
@@ -37,4 +37,5 @@ def DistogramParser(input):
         unique_contacts = unique_by_key(output, key=itemgetter(0))
         output = [(*contact[0], *contact[1:]) for contact in unique_contacts]
         output = sorted(output, key=itemgetter(2), reverse=True)
+        output.append('DISTO')
         return output

--- a/parsers/distogramparser.py
+++ b/parsers/distogramparser.py
@@ -1,0 +1,40 @@
+from operator import itemgetter
+from utils import unique_by_key
+from utils.exceptions import InvalidFormat
+
+
+def DistogramParser(input):
+    contents = input.split('\n')
+    output = []
+    res_1_idx = 0
+    res_2_idx = 1
+    raw_score_idx = 2
+    line_size = 13
+
+    for idx, line in enumerate(contents):
+
+        line = line.lstrip().rstrip().split()
+
+        if not line or len(line) < line_size or not line[res_1_idx].isdigit() or not line[res_2_idx].isdigit():
+            continue
+
+        res_1 = int(line[res_1_idx])
+        res_2 = int(line[res_2_idx])
+        seq_distance = res_1 - res_2
+
+        if abs(seq_distance) >= 5:
+            raw_score = float(line[raw_score_idx])
+            distance_probabilities = [float(p) for p in line[raw_score_idx + 1:]]
+            distance_score = max(distance_probabilities)
+            distance_bin = distance_probabilities.index(distance_score)
+            contact = [res_1, res_2, raw_score, distance_bin, distance_score]
+            contact[:2] = sorted(contact[:2], reverse=True)
+            output.append((tuple(contact[:2]), *contact[2:]))
+
+    if not output:
+        raise InvalidFormat('Unable to parse contacts')
+    else:
+        unique_contacts = unique_by_key(output, key=itemgetter(0))
+        output = [(*contact[0], *contact[1:]) for contact in unique_contacts]
+        output = sorted(output, key=itemgetter(2), reverse=True)
+        return output

--- a/parsers/tests/test_ccmpredparser.py
+++ b/parsers/tests/test_ccmpredparser.py
@@ -38,6 +38,7 @@ D U M M Y
 """
         with self.assertRaises(InvalidFormat):
             output = CCMpredParser(dummy_prediction)
+            self.assertListEqual(output, [])
 
     def test_3(self):
         dummy_prediction = """###

--- a/parsers/tests/test_ccmpredparser.py
+++ b/parsers/tests/test_ccmpredparser.py
@@ -38,3 +38,11 @@ D U M M Y
 """
         with self.assertRaises(InvalidFormat):
             output = CCMpredParser(dummy_prediction)
+
+    def test_3(self):
+        dummy_prediction = """###
+CRYST1   73.530   39.060   23.150  90.00  90.00  90.00 P 21 21 21    4
+100 8 5.382865
+"""
+        with self.assertRaises(InvalidFormat):
+            output = CCMpredParser(dummy_prediction)

--- a/parsers/tests/test_distogramparser.py
+++ b/parsers/tests/test_distogramparser.py
@@ -1,0 +1,52 @@
+import unittest
+from parsers import DistogramParser
+from utils.exceptions import InvalidFormat
+
+
+class ContactParserTestCase(unittest.TestCase):
+
+    def test_1(self):
+        dummy_prediction = """PFRMAT RR
+TARGET T0999
+AUTHOR 1234-5678-9000
+REMARK Predictor remarks
+METHOD Description of methods used
+METHOD Description of methods used
+RMODE 2
+MODEL 1
+1 8 .72 .345 .225 .15 .15 .1 .03 0 0 0 0
+1 10 .715 .34 .225 .15 .15 .1 .035 0 0 0 0
+31 38 .71 0 .56 .15 .12 .13 .04 0 0 0 0
+10 20 .69 .34 .22 .13 .11 .1 .04 .06 0 0 0    
+30 37 .67 .33 .21 .13 .1 .15 .04 .04 0 0 0
+11 29 .65 .33 .21 .11 .12 .15 .04 .04 0 0 0
+1 9 .63 0 .51 .12 .15 .15 .04 .03 0 0 0
+21 37 .505 0 .2 .305 .25 .15 .07 .025 0 0 0
+8 15 .4 0 .1 .3 .2 .1 .15 .05 .05 .05 0
+3 14 .4 0 .2 .2 .1 .1 .15 .05 .05 .05 .1
+5 15 .35 0 .15 .2 .1 .1 .15 .05 .05 .1 .1
+7 14 .2 0 0 .2 .3 .1 .1 .05 .05 .1 .1
+END"""
+        expected_res1 = [8, 10, 38, 20, 37, 29, 9, 37, 15, 14, 15, 14]
+        expected_res2 = [1, 1, 31, 10, 30, 11, 1, 21, 8, 3, 5, 7]
+        expected_raw_score = [0.72, 0.715, 0.71, 0.69, 0.67, 0.65, 0.63, 0.505, 0.4, 0.4, 0.35, 0.2]
+        expected_bin_distance = [0, 0, 1, 0, 0, 0, 1, 2, 2, 1, 2, 3]
+        expected_bin_score = [0.345, 0.34, 0.56, 0.34, 0.33, 0.33, 0.51, 0.305, 0.3, 0.2, 0.2, 0.3]
+
+        output = DistogramParser(dummy_prediction)
+
+        self.assertEqual(12, len(output))
+        self.assertListEqual(expected_res1, [contact[0] for contact in output])
+        self.assertListEqual(expected_res2, [contact[1] for contact in output])
+        self.assertListEqual(expected_raw_score, [contact[2] for contact in output])
+        self.assertListEqual(expected_bin_distance, [contact[3] for contact in output])
+        self.assertListEqual(expected_bin_score, [contact[4] for contact in output])
+
+    def test_2(self):
+        dummy_prediction = """###
+D U M M Y
+100 8 5.382865
+"""
+        with self.assertRaises(InvalidFormat):
+            output = DistogramParser(dummy_prediction)
+            self.assertListEqual(output, [])

--- a/parsers/tests/test_distogramparser.py
+++ b/parsers/tests/test_distogramparser.py
@@ -35,6 +35,7 @@ END"""
 
         output = DistogramParser(dummy_prediction)
 
+        self.assertEquals('DISTO', output.pop(-1))
         self.assertEqual(12, len(output))
         self.assertListEqual(expected_res1, [contact[0] for contact in output])
         self.assertListEqual(expected_res2, [contact[1] for contact in output])

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -25,6 +25,10 @@ class WimleyWhiteHydrophobicityScale(Enum):
     K = 1.81
 
 
+def conplot_version():
+    return 'v0.2.4'
+
+
 def get_base_url():
     if 'PRODUCTION_SERVER' in os.environ:
         return '/conplot'
@@ -135,6 +139,18 @@ def get_display_control_card(*args, **kwargs):
     from utils.plot_utils import get_display_control_card
 
     return get_display_control_card(*args, **kwargs)
+
+
+def is_redis_available(*args, **kwargs):
+    from utils.cache_utils import is_redis_available
+
+    return is_redis_available(*args, **kwargs)
+
+
+def get_active_sessions(*args, **kwargs):
+    from utils.cache_utils import get_active_sessions
+
+    return get_active_sessions(*args, **kwargs)
 
 
 def load_figure_json(*args, **kwargs):

--- a/utils/app_utils.py
+++ b/utils/app_utils.py
@@ -62,7 +62,7 @@ def serve_url(url, session_id, cache, logger):
         else:
             return layouts.Plot(session_id, username)
     elif url == UrlIndex.HELP.value:
-        return layouts.Help(session_id, username)
+        return layouts.Help(session_id, username, cache)
     elif url == UrlIndex.RIGDEN.value:
         return layouts.RigdenLab(session_id, username)
     elif url == UrlIndex.PRIVACY_POLICY.value:

--- a/utils/cache_utils.py
+++ b/utils/cache_utils.py
@@ -127,3 +127,14 @@ def remove_sequence(session_id, cache):
         cache.hdel(session_id, decompress_data(cache.hget(session_id, CacheKeys.SEQUENCE.value)))
         cache.hdel(session_id, CacheKeys.SEQUENCE.value)
         cache.hdel(session_id, CacheKeys.SEQUENCE_HYDROPHOBICITY.value)
+
+
+def is_redis_available(cache):
+    try:
+        cache.ping()
+        return True
+    except:
+        return False
+
+def get_active_sessions(cache):
+    return cache.dbsize()

--- a/utils/color_palettes.py
+++ b/utils/color_palettes.py
@@ -148,9 +148,17 @@ class Custom_ColorPalettes(Enum):
     PALETTE_2 = Custom_GrayColorPalette
 
 
+class Heatmap_ColorPalettes(Enum):
+    PALETTE_1 = 'Greys'
+    PALETTE_2 = 'viridis'
+    PALETTE_3 = 'balance'
+    PALETTE_4 = 'Inferno'
+
+
 class DatasetColorPalettes(Enum):
     membranetopology = MembraneTopology_ColorPalettes
     secondarystructure = SecondaryStructure_ColorPalettes
     disorder = Disorder_ColorPalettes
     conservation = Conservation_ColorPalettes
     custom = Custom_ColorPalettes
+    heatmap = Heatmap_ColorPalettes

--- a/utils/plot_utils.py
+++ b/utils/plot_utils.py
@@ -15,7 +15,7 @@ DisplayControlSettings = namedtuple('DisplayControlSettings', ('available_tracks
                                                                'transparent', 'track_separation', 'selected_cmaps',
                                                                'available_maps', 'superimpose', 'selected_palettes',
                                                                'seq_length', 'seq_fname', 'alpha', 'cmap_selection',
-                                                               'available_cmaps'))
+                                                               'available_cmaps', 'distance_matrix', 'verbose_labels'))
 
 
 class DefaultTrackLayout(Enum):
@@ -26,13 +26,36 @@ class DefaultTrackLayout(Enum):
     CUSTOM = DatasetReference.CUSTOM.value.encode()
 
 
+class PaletteDefaultLayout(Enum):
+    MEMBRANE_TOPOLOGY = DatasetReference.MEMBRANE_TOPOLOGY.value.encode()
+    SECONDARY_STRUCTURE = DatasetReference.SECONDARY_STRUCTURE.value.encode()
+    DISORDER = DatasetReference.DISORDER.value.encode()
+    CONSERVATION = DatasetReference.CONSERVATION.value.encode()
+    CUSTOM = DatasetReference.CUSTOM.value.encode()
+    HEATMAP = b'heatmap'
+
+
+class DistanceLabels(Enum):
+    BIN_0 = 'd ≤ 4Å'
+    BIN_1 = '4Å < d ≤ 6Å'
+    BIN_2 = '6Å < d ≤ 8Å'
+    BIN_3 = '8Å < d ≤ 10Å'
+    BIN_4 = '10Å < d ≤ 12Å'
+    BIN_5 = '12Å < d ≤ 14Å'
+    BIN_6 = '14Å < d ≤ 16Å'
+    BIN_7 = '16Å < d ≤ 18Å'
+    BIN_8 = '18Å < d ≤ 20Å'
+    BIN_9 = 'd > 20Å'
+
+
 def create_ConPlot(session_id, cache, trigger, selected_tracks, cmap_selection, selected_palettes, factor=2,
-                   contact_marker_size=5, track_marker_size=5, track_separation=2, transparent=True, superimpose=False):
+                   contact_marker_size=5, track_marker_size=5, track_separation=2, transparent=True, superimpose=False,
+                   distance_matrix=False, verbose_labels=False):
     session = cache.hgetall(session_id)
-    session, display_settings, error = process_args(session, trigger, selected_tracks, cmap_selection,
-                                                    factor, contact_marker_size, track_separation,
-                                                    transparent, selected_palettes, superimpose,
-                                                    track_marker_size)
+    session, display_settings, verbose_labels, error = process_args(session, trigger, selected_tracks, cmap_selection,
+                                                                    factor, contact_marker_size, track_separation,
+                                                                    transparent, selected_palettes, superimpose,
+                                                                    track_marker_size, distance_matrix, verbose_labels)
 
     if error is not None:
         cache_utils.remove_figure(session_id, cache)
@@ -48,16 +71,30 @@ def create_ConPlot(session_id, cache, trigger, selected_tracks, cmap_selection, 
             seq_length=display_settings.seq_length, factor=display_settings.factor)
         figure.add_trace(
             create_superimposed_contact_traces(reference, marker_size=display_settings.contact_marker_size,
-                                               color='grey', symbol='circle')
+                                               color='grey', symbol='circle', verbose_labels=verbose_labels)
         )
         figure.add_trace(
             create_superimposed_contact_traces(mismatched, marker_size=display_settings.contact_marker_size,
-                                               color='red', symbol='circle')
+                                               color='red', symbol='circle', verbose_labels=verbose_labels)
         )
         figure.add_trace(
             create_superimposed_contact_traces(matched, marker_size=display_settings.contact_marker_size,
-                                               color='black', symbol='circle')
+                                               color='black', symbol='circle', verbose_labels=verbose_labels)
         )
+
+    elif display_settings.distance_matrix:
+
+        heat = [[0 for x in range(display_settings.seq_length + 1)] for y in range(display_settings.seq_length + 1)]
+        hover = [[None for x in range(display_settings.seq_length + 1)] for y in range(display_settings.seq_length + 1)]
+
+        for idx, fname in enumerate(display_settings.cmap_selection):
+            if fname == '---':
+                continue
+            heat, hover = create_distogram(session[fname.encode()], idx, heat, hover, verbose_labels)
+
+        palette = color_palettes.Heatmap_ColorPalettes.__getattr__(display_settings.selected_palettes[-1]).value
+        figure.add_trace(create_heatmap(hovertext=hover, distances=heat, colorscale=palette))
+
     else:
         for idx, fname in enumerate(display_settings.cmap_selection):
             if fname == '---':
@@ -65,7 +102,7 @@ def create_ConPlot(session_id, cache, trigger, selected_tracks, cmap_selection, 
             figure.add_trace(
                 create_contact_trace(cmap=session[fname.encode()], idx=idx, factor=display_settings.factor,
                                      marker_size=display_settings.contact_marker_size,
-                                     seq_length=display_settings.seq_length)
+                                     seq_length=display_settings.seq_length, verbose_labels=verbose_labels)
             )
 
     for idx, fname in enumerate(display_settings.selected_tracks):
@@ -112,7 +149,9 @@ def get_display_control_card(display_settings):
                                          track_separation=display_settings.track_separation,
                                          selected_cmaps=display_settings.cmap_selection,
                                          available_maps=display_settings.available_cmaps,
-                                         selected_palettes=display_settings.selected_palettes)
+                                         selected_palettes=display_settings.selected_palettes,
+                                         distance_matrix=display_settings.distance_matrix,
+                                         verbose_labels=display_settings.verbose_labels)
 
 
 def load_figure_json(figure_json):
@@ -151,7 +190,7 @@ def lookup_input_errors(session):
 
     mismatched = []
     for cmap_fname in session[DatasetReference.CONTACT_MAP.value.encode()]:
-        if session[cmap_fname.encode()][-1] == 'PDB':
+        if session[cmap_fname.encode()][-1] == 'PDB' or session[cmap_fname.encode()][-1] == 'DISTO':
             cmap_max_register = max((max(session[cmap_fname.encode()][:-1], key=itemgetter(0))[0],
                                      max(session[cmap_fname.encode()][:-1], key=itemgetter(1))[0]))
         else:
@@ -177,12 +216,12 @@ def lookup_input_errors(session):
 
 
 def process_args(session, trigger, selected_tracks, cmap_selection, factor, contact_marker_size, track_separation,
-                 transparent, selected_palettes, superimpose, track_marker_size):
+                 transparent, selected_palettes, superimpose, track_marker_size, distance_matrix, verbose_labels):
     session = decompress_session(session)
 
     error = lookup_input_errors(session)
     if error is not None:
-        return None, None, error
+        return None, None, None, error
 
     available_tracks, available_cmaps = get_available_data(session)
     seq_fname = session[DatasetReference.SEQUENCE.value.encode()]
@@ -215,9 +254,16 @@ def process_args(session, trigger, selected_tracks, cmap_selection, factor, cont
                                               available_maps=available_cmaps, superimpose=superimpose,
                                               selected_palettes=selected_palettes, axis_range=axis_range,
                                               seq_length=seq_length, seq_fname=seq_fname, alpha=alpha,
-                                              cmap_selection=cmap_selection, available_cmaps=available_cmaps)
+                                              cmap_selection=cmap_selection, available_cmaps=available_cmaps,
+                                              distance_matrix=distance_matrix, verbose_labels=verbose_labels)
 
-    return session, display_settings, error
+    if verbose_labels:
+        fnames = [fname for fname in selected_tracks if fname != '---']
+        verbose_labels = get_verbose_labels(fnames, session[display_settings.seq_fname.encode()], session)
+    else:
+        verbose_labels = None
+
+    return session, display_settings, verbose_labels, error
 
 
 def get_available_data(session):
@@ -285,6 +331,15 @@ def create_figure(axis_range):
     )
 
 
+def create_heatmap(distances, hovertext=None, colorscale='Greys'):
+    return go.Heatmap(
+        z=distances,
+        hovertext=hovertext,
+        colorscale=colorscale,
+        hoverinfo='text' if hovertext is not None else 'none',
+    )
+
+
 def create_scatter(x, y, symbol, marker_size, color, hovertext=None):
     return go.Scatter(
         x=x,
@@ -300,8 +355,44 @@ def create_scatter(x, y, symbol, marker_size, color, hovertext=None):
     )
 
 
-def create_contact_trace(cmap, idx, seq_length, marker_size=5, factor=2):
+def create_distogram(cmap, idx, distances, hover, verbose_labels=None):
+    if idx == 1:
+        idx_x = 1
+        idx_y = 0
+    else:
+        idx_x = 0
+        idx_y = 1
+
     if cmap[-1] == 'PDB':
+        del cmap[-1]
+
+    elif cmap[-1] == 'DISTO':
+        hover_template = 'Contact: {} - {} | Distance {} | Confidence: {}'
+        cmap = cmap[:-1]
+
+        for contact in cmap:
+            distances[contact[idx_x]][contact[idx_y]] = 9 - contact[3]
+            label = DistanceLabels.__getitem__(('BIN_{}'.format(contact[3]))).value
+            hover_label = hover_template.format(contact[idx_x], contact[idx_y], label, contact[4])
+            if verbose_labels is not None:
+                hover_label += '<br>%s<br>%s' % (verbose_labels[contact[idx_x] - 1], verbose_labels[contact[idx_y] - 1])
+            hover[contact[idx_x]][contact[idx_y]] = hover_label
+
+        return distances, hover
+
+    hover_template = 'Contact: {} - {} | Confidence: {}'
+    for contact in cmap:
+        distances[contact[idx_x]][contact[idx_y]] = contact[2]
+        hover_label = hover_template.format(contact[idx_x], contact[idx_y], contact[2])
+        if verbose_labels is not None:
+            hover_label += '<br>%s<br>%s' % (verbose_labels[contact[idx_x] - 1], verbose_labels[contact[idx_y] - 1])
+        hover[contact[idx_x]][contact[idx_y]] = hover_label
+
+    return distances, hover
+
+
+def create_contact_trace(cmap, idx, seq_length, marker_size=5, factor=2, verbose_labels=None):
+    if cmap[-1] == 'PDB' or cmap[-1] == 'DISTO':
         del cmap[-1]
 
     if factor != 0:
@@ -314,8 +405,16 @@ def create_contact_trace(cmap, idx, seq_length, marker_size=5, factor=2):
     for contact in cmap:
         res1_list.append(contact[0])
         res2_list.append(contact[1])
-        hover_1.append('Contact: %s - %s | Confidence: %s' % (contact[0], contact[1], contact[2]))
-        hover_2.append('Contact: %s - %s | Confidence: %s' % (contact[1], contact[0], contact[2]))
+        if verbose_labels is not None:
+            res_1_label = verbose_labels[contact[0] - 1]
+            res_2_label = verbose_labels[contact[1] - 1]
+            hover_1.append('Contact: %s - %s | Confidence: %s<br>%s<br>%s' % (
+                contact[0], contact[1], contact[2], res_1_label, res_2_label))
+            hover_2.append('Contact: %s - %s | Confidence: %s<br>%s<br>%s' % (
+                contact[1], contact[0], contact[2], res_2_label, res_1_label))
+        else:
+            hover_1.append('Contact: %s - %s | Confidence: %s' % (contact[0], contact[1], contact[2]))
+            hover_2.append('Contact: %s - %s | Confidence: %s' % (contact[1], contact[0], contact[2]))
 
     if idx == 1:
         return create_scatter(x=res1_list, y=res2_list, symbol='circle', hovertext=hover_1, marker_size=marker_size,
@@ -329,7 +428,7 @@ def create_contact_trace(cmap, idx, seq_length, marker_size=5, factor=2):
 def get_superimposed_contact_traces(reference_cmap, secondary_cmap, seq_length, factor=2):
     if factor != 0:
         secondary_cmap = secondary_cmap[:int(round(seq_length / factor, 0))]
-        if reference_cmap[-1] == 'PDB':
+        if reference_cmap[-1] == 'PDB' or reference_cmap[-1] == 'DISTO':
             del reference_cmap[-1]
         else:
             reference_cmap = reference_cmap[:int(round(seq_length / factor, 0))]
@@ -354,7 +453,7 @@ def get_superimposed_contact_traces(reference_cmap, secondary_cmap, seq_length, 
     return reference, matched, mismatched
 
 
-def create_superimposed_contact_traces(contacts, marker_size=5, color='black', symbol='circle'):
+def create_superimposed_contact_traces(contacts, marker_size=5, color='black', symbol='circle', verbose_labels=None):
     res1_list = []
     res2_list = []
     hover_1 = []
@@ -363,8 +462,16 @@ def create_superimposed_contact_traces(contacts, marker_size=5, color='black', s
     for contact in contacts:
         res1_list.append(contact[0])
         res2_list.append(contact[1])
-        hover_1.append('Contact: %s - %s | Confidence: %s' % (contact[0], contact[1], contact[2]))
-        hover_2.append('Contact: %s - %s | Confidence: %s' % (contact[1], contact[0], contact[2]))
+        if verbose_labels is not None:
+            res_1_label = verbose_labels[contact[0] - 1]
+            res_2_label = verbose_labels[contact[1] - 1]
+            hover_1.append('Contact: %s - %s | Confidence: %s<br>%s<br>%s' % (
+                contact[0], contact[1], contact[2], res_1_label, res_2_label))
+            hover_2.append('Contact: %s - %s | Confidence: %s<br>%s<br>%s' % (
+                contact[1], contact[0], contact[2], res_2_label, res_1_label))
+        else:
+            hover_1.append('Contact: %s - %s | Confidence: %s' % (contact[0], contact[1], contact[2]))
+            hover_2.append('Contact: %s - %s | Confidence: %s' % (contact[1], contact[0], contact[2]))
 
     x = res1_list + res2_list
     y = res2_list + res1_list
@@ -443,3 +550,63 @@ def get_traces(prediction, dataset, track_idx, track_separation, marker_size, al
         traces.append(create_scatter(x, y, 'diamond', marker_size=marker_size, color=color, hovertext=hovertext))
 
     return traces
+
+
+def get_verbose_labels(fnames, sequence, session):
+    states_dict = {
+        DatasetReference.MEMBRANE_TOPOLOGY.value: {
+            1: 'INSIDE',
+            2: 'OUTSIDE',
+            3: 'INSERTED'
+        },
+        DatasetReference.CONSERVATION.value: {
+            1: 'VARIABLE_1',
+            2: 'VARIABLE_2',
+            3: 'VARIABLE_3',
+            4: 'AVERAGE_4',
+            5: 'AVERAGE_5',
+            6: 'AVERAGE_6',
+            7: 'CONSERVED_7',
+            8: 'CONSERVED_8',
+            9: 'CONSERVED_9'
+        },
+        DatasetReference.CUSTOM.value: {
+            1: 'CUSTOM_1',
+            2: 'CUSTOM_2',
+            3: 'CUSTOM_3',
+            4: 'CUSTOM_4',
+            5: 'CUSTOM_5',
+            6: 'CUSTOM_6',
+            7: 'CUSTOM_7',
+            8: 'CUSTOM_8',
+            9: 'CUSTOM_9',
+            10: 'CUSTOM_10',
+            11: 'CUSTOM_11',
+            'NAN': 'CUSTOM_NAN'
+        },
+        DatasetReference.DISORDER.value: {
+            1: 'DISORDER',
+            2: 'ORDER'
+        },
+        DatasetReference.SECONDARY_STRUCTURE.value: {
+            1: 'HELIX',
+            2: 'COIL',
+            3: 'SHEET'
+        }
+    }
+
+    all_predictions = []
+    for fname in set(fnames):
+        dataset = get_dataset(session, fname)
+        dataset_dict = states_dict[dataset]
+        prediction = [dataset_dict[x] for x in session[fname.encode()]]
+        all_predictions.append(prediction)
+
+    labels = []
+    for idx, residue in enumerate(sequence, 1):
+        current_label = 'Residue {} ({})'.format(idx, residue)
+        for prediction in all_predictions:
+            current_label += ' | {}'.format(prediction[idx - 1])
+        labels.append(current_label)
+
+    return labels

--- a/utils/postgres_utils.py
+++ b/utils/postgres_utils.py
@@ -101,13 +101,14 @@ class SqlQueries(Enum):
                SqlFieldNames.SESSION_PKID.value)
 
 
-def is_postgres_available(logger):
+def is_postgres_available(logger=None):
     try:
         connection = psycopg2.connect(os.environ['DATABASE_URL'], sslmode='disable')
         connection.close()
         return True
     except (Exception, psycopg2.DatabaseError) as error:
-        logger.error('Cannot establish connection with postgres database! {}'.format(error))
+        if logger is not None:
+            logger.error('Cannot establish connection with postgres database! {}'.format(error))
         return False
 
 


### PR DESCRIPTION
This update includes:
- Residue-residue distance prediction files (format CASPRR-MODE-2) can be uploaded and visualised as a heatmap. 
- New heatmap mode. Intended for the visualisation of residue-residue distance prediction files, but contact maps can also be viewed (colouring will then correspond with contact confidence). The mode can be activated with a switch (by default off) and four colour palettes are available. 
- Server status section added to the help page.
- Added an example button. Now users can load example session by clicking the button (instead of download and re-upload data).
- Contact map spikes mode has been changed to "across" to enable easy cross visualisation of contacts and the annotation in the diagonal.
- Verbose labels switch added. By default off, if activated the hover text of the contact markers displays information about all the associated predictions for each given residue.
- Fixes issue #116 
- Fixes issue #115 